### PR TITLE
Profile and Example for ITI-78 response

### DIFF
--- a/input/fsh/PDQmPatient.fsh
+++ b/input/fsh/PDQmPatient.fsh
@@ -12,3 +12,18 @@ The PDQm Patient Profile
 * modifierExtension 0..0
 * extension contains http://hl7.org/fhir/StructureDefinition/patient-mothersMaidenName named MothersMaidenName 0..1 
 
+Profile:        QueryPatientResourceResponseMessage
+Parent:         Bundle
+Id:             IHE.PDQm.QueryPatientResourceResponseMessage
+Title:          "PDQm Query Patient Resource Response message"
+Description:    "A profile on the Query Patient Resource Response message for ITI-78"
+* type = #searchset (exactly)
+* total 1..
+* entry ^slicing.discriminator[0].type = #profile
+* entry ^slicing.discriminator[0].path = "resource"
+* entry ^slicing.rules = #open
+* entry.fullUrl 1..
+* entry contains Patient 0..*
+* entry[Patient] ^short = "Patient"
+* entry[Patient].resource 1..
+* entry[Patient].resource only PDQmPatient

--- a/input/fsh/ex-dummy.fsh
+++ b/input/fsh/ex-dummy.fsh
@@ -36,3 +36,17 @@ Usage: #example
 * birthDate = "1923-07-25"
 * address.state = "WI"
 * address.country = "USA"
+
+Instance:   ex-QueryPatientResourceResponseMessage
+InstanceOf: IHE.PDQm.QueryPatientResourceResponseMessage
+Title:      "Example of a Query Patient Resource Response message"
+Description: "Example of a Query Patient Resource Response message with a single Patient"
+Usage: #example
+* meta.security = http://terminology.hl7.org/CodeSystem/v3-ActReason#HTEST
+* type = #searchset
+* link[0].relation = "self"
+* link[0].url = "test.fhir.net/R4/fhir/Patient?family=Schmidt"
+* total = 1
+* timestamp = 2023-09-25T15:42:00Z
+* entry[0].fullUrl = "http://example.org/DocumentReference/ex-DocumentReferenceMinimal"
+* entry[0].resource = ex-patient

--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -26,7 +26,7 @@ dependencies:
   ihe.iti.balp:
     id: iheitibasicaudit
     uri: https://profiles.ihe.net/ITI/BALP/ImplementationGuide/ihe.iti.balp
-    version: current #1.1.1
+    version: 1.1.2
 
 parameters:  # see https://confluence.hl7.org/display/FHIR/Implementation+Guide+Parameters
   path-resource:


### PR DESCRIPTION
At the IHE connectathon we want to verify that the PDQm Bundle response is valid and we need a profile to describe the return result of the query (like for MHD). Profile and Example have been added.

We added this branch for connectathon testing in the validator.