### PR TITLE
remove inputProfile because of error

### DIFF
--- a/input/fsh/PDQmMatch.fsh
+++ b/input/fsh/PDQmMatch.fsh
@@ -19,7 +19,6 @@ and to constring the output parameters to use the [PDQm Patient Profile](Structu
 * type = true
 * instance = false
 * code = #match
-* inputProfile = Canonical(IHE.PDQm.MatchParametersIn)
 
 * parameter[+]
   * name = #resource
@@ -28,6 +27,7 @@ and to constring the output parameters to use the [PDQm Patient Profile](Structu
   * max = "1"
   * documentation = "Use this to provide an entire set of patient details for the MPI to match against (e.g. POST a patient record to Patient/$match)."
   * type = #Patient
+  * targetProfile[+] = Canonical(IHE.PDQm.MatchInputPatient)
 * parameter[+]
   * name = #onlyCertainMatches
   * use = #in


### PR DESCRIPTION
Closes PDQm OperationDefinition #124


## 📑 Description
Removing the inputProfile and adding the targetProfile as we have done it for the PDQm output parametet

## ✅ Checks
see ci-build of change: https://build.fhir.org/ig/IHE/ITI.PDQm/branches/oe_cp1314_followup/qa.html

